### PR TITLE
FIX: Requires linking against user32.dll

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -115,6 +115,6 @@ class HarfbuzzConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")
         if self.settings.os == "Windows" and not self.options.shared:
-            self.cpp_info.system_libs.extend(["dwrite", "rpcrt4", "usp10", "gdi32"])
+            self.cpp_info.system_libs.extend(["dwrite", "rpcrt4", "usp10", "gdi32", "user32"])
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])


### PR DESCRIPTION
When building [the new Qt 5.14.2 recipe](https://github.com/bincrafters/community/issues/1161) on our CI, we ran into linker errors (output is partly in German with broken UTF-8, sorry):

```
link /NOLOGO /DYNAMICBASE /NXCOMPAT /OPT:REF /INCREMENTAL:NO /SUBSYSTEM:CONSOLE "/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" /MANIFEST:embed /OUT:harfbuzz.exe @C:\Users\nexenio\AppData\Local\Temp\harfbuzz.exe.5012.218.jom
> harfbuzz.lib(harfbuzz.obj) : error LNK2019: Verweis auf nicht aufgelÃ·stes externes Symbol "__imp_GetDC" in Funktion ""struct hb_blob_t * __cdecl _hb_gdi_reference_table(struct hb_face_t *,unsigned int,void *)" (?_hb_gdi_reference_table@@YAPEAUhb_blob_t@@PEAUhb_face_t@@IPEAX@Z)".
> harfbuzz.lib(harfbuzz.obj) : error LNK2019: Verweis auf nicht aufgelÃ·stes externes Symbol "__imp_ReleaseDC" in Funktion ""struct hb_blob_t * __cdecl _hb_gdi_reference_table(struct hb_face_t *,unsigned int,void *)" (?_hb_gdi_reference_table@@YAPEAUhb_blob_t@@PEAUhb_face_t@@IPEAX@Z)".
> harfbuzz.exe : fatal error LNK1120: 2 nicht aufgelÃ·ste Externe
> jom: C:\.conan\1d988d\1\config.tests\harfbuzz\Makefile [harfbuzz.exe] Error 1120
 => source failed verification.
test config.qtbase_gui.libraries.harfbuzz FAILED
```

I.e. symbols for `__imp_GetDC` and `__imp_ReleaseDC` are missing. Those are provided by `user32.dll` [according to Microsoft's documentation](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc).

The error happens during Qt's configure step, resulting in an output like that:

```
Checking for HarfBuzz... no

[...]

HarfBuzz ............................... yes
    Using system HarfBuzz ................ no

[...]

ERROR: Feature 'system-harfbuzz' was enabled, but the pre-condition 'features.harfbuzz && libs.harfbuzz' failed.
```

By adding `user32` to the list of required `system_libs` we managed to successfully build Qt with harfbuzz on our CI.